### PR TITLE
Update useProofsets.ts

### DIFF
--- a/hooks/useProofsets.ts
+++ b/hooks/useProofsets.ts
@@ -21,7 +21,7 @@ const fetchProofSetDetails = async (
   pdpUrl: string
 ): Promise<ProofSetDetails | null> => {
   try {
-    const response = await fetch(`${pdpUrl}pdp/proof-sets/${proofsetId}`, {
+    const response = await fetch(`${pdpUrl}/pdp/proof-sets/${proofsetId}`, {
       method: "GET",
       headers: {
         Accept: "application/json",


### PR DESCRIPTION
The fetch request is missing a '/' after the pdpurl string. This caused errors with loading the proofsetDetails in this hook.